### PR TITLE
Remove emoji once it flies past page height

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,7 @@
         var _doc = document.documentElement;
         var emoji = emojis[Math.floor(Math.random() * emojis.length)];
         var angle = Math.floor(Math.random() * 360);
+        var pageHeight = _doc.scrollHeight;
 
         var _span = document.createElement('span');
         _span.classList.add('zoomy');
@@ -189,7 +190,7 @@
         _span = _doc.appendChild(_span);
 
         function zoom() {
-          if (x < 0 || x > _doc.clientWidth || y < 0) {
+          if (x < 0 || x > _doc.clientWidth || y < 0 || y > pageHeight) {
             _doc.removeChild(_span);
             return;
           }


### PR DESCRIPTION
## Context
_Resolves #6_ 

Currently if an emoji flies straight down the page's vertical scroll will increase indefinitely

![indefinite vertical scroll bug](https://user-images.githubusercontent.com/5287128/66249983-4706c680-e77f-11e9-9dd8-e92c71e38cf0.gif)

## Changes
- Remove emoji once it flies past page height

![emoji deleted after exiting page boundary](https://user-images.githubusercontent.com/5287128/66249993-6dc4fd00-e77f-11e9-8c80-2fc606cb147e.gif)

